### PR TITLE
fix: typo

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,7 +50,7 @@ export class FunctionsClient {
       const { responseType } = invokeOptions ?? {}
       if (!responseType || responseType === 'json') {
         data = await response.json()
-      } else if (responseType === 'arraybuffer') {
+      } else if (responseType === 'arrayBuffer') {
         data = await response.arrayBuffer()
       } else if (responseType === 'blob') {
         data = await response.blob()

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,7 +5,7 @@ export type Fetch = typeof crossFetch
 export enum ResponseType {
   json,
   text,
-  arraybuffer,
+  arrayBuffer,
   blob,
 }
 


### PR DESCRIPTION
In case it wasn't intentional. It's inconsistent with https://github.com/supabase/supabase/blob/014fc681e1ef8eebca803d2632a31217bf632fff/web/spec/supabase.yml#L999