### PR TITLE
fix: change default type for invoke to json

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 import { resolveFetch } from './helper'
-import { Fetch, FunctionInvokeOptions } from './types'
+import { Fetch, FunctionInvokeOptions, JSONObject } from './types'
 
 export class FunctionsClient {
   protected url: string
@@ -29,7 +29,7 @@ export class FunctionsClient {
    * `body`: the body of the request
    * `responseType`: how the response should be parsed. The default is `json`
    */
-  async invoke<T = string>(
+  async invoke<T = JSONObject>(
     functionName: string,
     invokeOptions?: FunctionInvokeOptions
   ): Promise<{ data: T | null; error: Error | null }> {

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,3 +14,9 @@ export type FunctionInvokeOptions = {
   body?: Blob | BufferSource | FormData | URLSearchParams | ReadableStream<Uint8Array> | string
   responseType?: keyof typeof ResponseType
 }
+
+export type JSONValue = string | number | boolean | { [key: string]: JSONValue } | Array<JSONValue>
+
+export interface JSONObject {
+  [key: string]: JSONValue
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix: change default type for invoke to json

## What is the current behavior?

default invoke type is string
```
async invoke<T = string>(
    functionName: string,
    invokeOptions?: FunctionInvokeOptions
  ): Promise<{ data: T | null; error: Error | null }>
```

## What is the new behavior?

default invoke type is json object
```
async invoke<T = JSONObject>(
    functionName: string,
    invokeOptions?: FunctionInvokeOptions
  ): Promise<{ data: T | null; error: Error | null }>
```

```
export type JSONValue = string | number | boolean | { [key: string]: JSONValue } | Array<JSONValue>

export interface JSONObject {
  [key: string]: JSONValue
}
```

## Additional context

our default responseType is json so we have decided to change it
