### PR TITLE
Fix/api

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,7 @@ export class FunctionsClient {
   async invoke<T = any>(
     functionName: string,
     invokeOptions?: FunctionInvokeOptions
-  ): Promise<{ data: T | null; error: Error | null }> {
+  ): Promise<{ data: T; error: null } | { data: null; error: Error }> {
     try {
       const { headers, body } = invokeOptions ?? {}
       const response = await this.fetch(`${this.url}/${functionName}`, {


### PR DESCRIPTION
- fix: put all optional params in an object
- fix: default invoke T
  - `responseType` is `json` by default so `any` is more appriopriate
- fix: invoke response type