### PR TITLE
fix: FunctionsClient constructor default options

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,15 +9,15 @@ export class FunctionsClient {
   constructor(
     url: string,
     {
-      headers = {},
+      headers,
       customFetch,
     }: {
       headers?: Record<string, string>
       customFetch?: Fetch
-    }
+    } = {}
   ) {
     this.url = url
-    this.headers = headers
+    this.headers = headers ?? {}
     this.fetch = resolveFetch(customFetch)
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,7 +9,7 @@ export class FunctionsClient {
   constructor(
     url: string,
     {
-      headers,
+      headers = {},
       customFetch,
     }: {
       headers?: Record<string, string>
@@ -17,7 +17,7 @@ export class FunctionsClient {
     } = {}
   ) {
     this.url = url
-    this.headers = headers ?? {}
+    this.headers = headers
     this.fetch = resolveFetch(customFetch)
   }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

fix FunctionsClient constructor

## What is the current behavior?

FunctionsClient constructor requires to pass `{}` as options if you don't want to pass headers or fetch

## What is the new behavior?

Add `options` default value `{}` in FunctionsClient constructor