### PR TITLE
fix #20: invoke does not throw on HTTP Error status codes

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -118,9 +118,9 @@ export class FunctionsClient {
       }
 
       const failure: FunctionsResponseFailure = { data: null, error }
-      if (status) (
+      if (status) {
         failure.status = status
-      )
+      }
       if (statusText) {
         failure.statusText = statusText
       }


### PR DESCRIPTION
## What kind of change does this PR introduce?

<code>invoke()</code> call throws on HTTP errors if <code>shouldThrowOnError</code> flag is set
Fixes #20 

## What is the current behavior?

<code>invoke()</code> does not report HTTP error status codes. 
In that case it returns a clean <code>{ data, error: null }</code> object with the 'data' property populated, and the HTTP status code is lost.

## What is the new behavior?

<code>invoke()</code> checks if HTTP status code is other than 2xx, then reports this as an error with the HTTP status code populated.
In addition, if the <code>shouldThrowOnError</code> flag is set, <code>invoke()</code> will throw rather than returning the <code>{data, error}</code> object.

This is more in line with the behavior of similar libraries (e.g. Firebase).

## Additional context

The proposed PR also exports an <code>HttpError</code> class that can be used
- to check whether the error thrown by the client is arising from a faulty HTTP status code vs. other possible errors (e.g. connection errors etc.). The check can be written as <code> if (error instanceof HttpError) {}</code>
- to extract and process upon the faulty HTTP status code with <code>if (error.statusCode === xxx) {}</code>
- to inspect the root cause of the error in case the responding serverless edge function returned the original error context. This is being forwarded by HttpError in its <code>error.data</code> property
