### PR TITLE
add content type headers only if func args are set

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -54,26 +54,28 @@ export class FunctionsClient {
     try {
       let _headers: Record<string, string> = {}
       let body: any
-      if (
-        (typeof Blob !== 'undefined' && functionArgs instanceof Blob) ||
-        functionArgs instanceof ArrayBuffer
-      ) {
-        // will work for File as File inherits Blob
-        // also works for ArrayBuffer as it is the same underlying structure as a Blob
-        _headers['Content-Type'] = 'application/octet-stream'
-        body = functionArgs
-      } else if (typeof functionArgs === 'string') {
-        // plain string
-        _headers['Content-Type'] = 'text/plain'
-        body = functionArgs
-      } else if (typeof FormData !== 'undefined' && functionArgs instanceof FormData) {
-        // don't set content-type headers
-        // Request will automatically add the right boundary value
-        body = functionArgs
-      } else {
-        // default, assume this is JSON
-        _headers['Content-Type'] = 'application/json'
-        body = JSON.stringify(functionArgs)
+      if (functionArgs && !Object.prototype.hasOwnProperty.call(headers, 'Content-Type')) {
+        if (
+          (typeof Blob !== 'undefined' && functionArgs instanceof Blob) ||
+          functionArgs instanceof ArrayBuffer
+        ) {
+          // will work for File as File inherits Blob
+          // also works for ArrayBuffer as it is the same underlying structure as a Blob
+          _headers['Content-Type'] = 'application/octet-stream'
+          body = functionArgs
+        } else if (typeof functionArgs === 'string') {
+          // plain string
+          _headers['Content-Type'] = 'text/plain'
+          body = functionArgs
+        } else if (typeof FormData !== 'undefined' && functionArgs instanceof FormData) {
+          // don't set content-type headers
+          // Request will automatically add the right boundary value
+          body = functionArgs
+        } else {
+          // default, assume this is JSON
+          _headers['Content-Type'] = 'application/json'
+          body = JSON.stringify(functionArgs)
+        }
       }
 
       const response = await this.fetch(`${this.url}/${functionName}`, {


### PR DESCRIPTION
and if the user hasn't passed in a content-type header via the constructor arguments

before we set application/json as the content type even if there are no function args set