### PR TITLE
fix: revert invoke function signature

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -5,6 +5,7 @@ import {
   FunctionsHttpError,
   FunctionsRelayError,
   FunctionsResponse,
+  FunctionInvokeOptions,
 } from './types'
 
 export class FunctionsClient {
@@ -38,23 +39,22 @@ export class FunctionsClient {
   /**
    * Invokes a function
    * @param functionName - the name of the function to invoke
-   * @param functionArgs - the arguments to the function
-   * @param options - function invoke options
-   * @param options.headers - headers to send with the request
+   * @param invokeOption.headers - object representing the headers to send with the request
+   * @param invokeOptions.body - the body of the request
    */
-  async invoke(
+  async invoke<T = any>(
     functionName: string,
-    functionArgs: any,
-    {
-      headers = {},
-    }: {
-      headers?: Record<string, string>
-    } = {}
-  ): Promise<FunctionsResponse> {
+    invokeOptions: FunctionInvokeOptions = {}
+  ): Promise<FunctionsResponse<T>> {
     try {
+      const { headers, body: functionArgs } = invokeOptions
+
       let _headers: Record<string, string> = {}
       let body: any
-      if (functionArgs && !Object.prototype.hasOwnProperty.call(headers, 'Content-Type')) {
+      if (
+        functionArgs &&
+        ((headers && !Object.prototype.hasOwnProperty.call(headers, 'Content-Type')) || !headers)
+      ) {
         if (
           (typeof Blob !== 'undefined' && functionArgs instanceof Blob) ||
           functionArgs instanceof ArrayBuffer

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,15 +4,15 @@ export type Fetch = typeof fetch
  * Response format
  *
  */
-interface FunctionsResponseSuccess {
-  data: any
+interface FunctionsResponseSuccess<T> {
+  data: T
   error: null
 }
 interface FunctionsResponseFailure {
   data: null
   error: any
 }
-export type FunctionsResponse = FunctionsResponseSuccess | FunctionsResponseFailure
+export type FunctionsResponse<T> = FunctionsResponseSuccess<T> | FunctionsResponseFailure
 
 export class FunctionsError extends Error {
   context: any
@@ -25,13 +25,13 @@ export class FunctionsError extends Error {
 
 export class FunctionsFetchError extends FunctionsError {
   constructor(context: any) {
-    super('Failed to perform request to Edge Function', 'FunctionsFetchError', context)
+    super('Failed to send a request to the Edge Function', 'FunctionsFetchError', context)
   }
 }
 
 export class FunctionsRelayError extends FunctionsError {
   constructor(context: any) {
-    super('Relay error communicating with deno backend', 'FunctionsRelayError', context)
+    super('Relay Error invoking the Edge Function', 'FunctionsRelayError', context)
   }
 }
 
@@ -39,4 +39,16 @@ export class FunctionsHttpError extends FunctionsError {
   constructor(context: any) {
     super('Edge Function returned a non-2xx status code', 'FunctionsHttpError', context)
   }
+}
+
+export type FunctionInvokeOptions = {
+  headers?: { [key: string]: string }
+  body?:
+    | File
+    | Blob
+    | ArrayBuffer
+    | FormData
+    | ReadableStream<Uint8Array>
+    | Record<string, any>
+    | string
 }


### PR DESCRIPTION
what we had in v1 was good. Having an object to pass in is better cos all arguments except function name we have are optional.

Also making invoke a generic type function so that you can type the value returned by your function