### PR TITLE
Update GitHub Actions

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,15 +14,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['16']
+        node: ['18']
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Node
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,16 +1,16 @@
-name: Release
+name: Tests
 
 on:
+  pull_request:
   push:
     branches:
       - main
-      - next
       - rc
   workflow_dispatch:
 
 jobs:
-  release:
-    name: Release / Node ${{ matrix.node }}
+  autotests:
+    name: Run tests
     strategy:
       matrix:
         node: ['18']
@@ -25,12 +25,9 @@ jobs:
         with:
           node-version: ${{ matrix.node }}
 
-      - run: |
-          npm ci
-          npm run build
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Create a release
-        run: npx semantic-release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+      - name: Run Test
+        run: npm run test
+        continue-on-error: true


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR updates GitHub actions to add a new Test workflow and also changes node version to 18 (next LTS from Oct 2022). Going with node 18 prevents us from having to polyfills for tests.

## What is the current behavior?

Current workflows use Node 16 and doesn't have a test workflow.

## What is the new behavior?

New test workflow will run on every PR and pushes to branchs `main` and `rc`.

## Additional context

NA
