### PR TITLE
update deno-relay to v1.5.0

### DIFF
--- a/test/relay/container.ts
+++ b/test/relay/container.ts
@@ -57,7 +57,7 @@ export async function runRelay(
 
   // create relay container
   log(`create relay ${slug + '-' + id}`)
-  const relay = await new GenericContainer('supabase/deno-relay:v1.1.0')
+  const relay = await new GenericContainer('supabase/deno-relay:v1.5.0')
     .withName(slug + '-' + id)
     .withBindMount(`${process.cwd()}/test/functions/${slug}`, `/home/deno/${slug}`, 'ro')
     .withNetworkMode(network.getName())

--- a/test/spec/hello.spec.ts
+++ b/test/spec/hello.spec.ts
@@ -242,7 +242,7 @@ describe('basic tests (hello function)', () => {
     expect(data).toEqual('Hello World')
   })
 
-  test('invoke with custom fetch wrong method', async () => {
+  test('invoke with custom fetch GET method', async () => {
     /**
      * @feature fetch
      */
@@ -262,10 +262,10 @@ describe('basic tests (hello function)', () => {
     log('invoke hello')
     const { data, error } = await fclient.invoke<string>('', {})
 
-    log('check error')
-    expect(error).not.toBeNull()
-    expect(error?.message).toEqual('Relay Error invoking the Edge Function')
-    expect(data).toBeNull()
+    log('assert no error')
+    expect(error).toBeNull()
+    log(`assert ${data} is equal to 'Hello World'`)
+    expect(data).toEqual('Hello World')
   })
 
   test('invoke hello with custom fetch override header', async () => {


### PR DESCRIPTION
## What kind of change does this PR introduce?

- update deno-relay to v1.5.0 in tests
- update functions invocation test with methods other than post as it is now allowed
