### PR TITLE
added support for different HTTP verbs in invoking functions

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -46,7 +46,7 @@ export class FunctionsClient {
     options: FunctionInvokeOptions = {}
   ): Promise<FunctionsResponse<T>> {
     try {
-      const { headers, body: functionArgs } = options
+      const { headers, method, body: functionArgs } = options
 
       let _headers: Record<string, string> = {}
       let body: any
@@ -78,7 +78,7 @@ export class FunctionsClient {
       }
 
       const response = await this.fetch(`${this.url}/${functionName}`, {
-        method: 'POST',
+        method: method || 'POST',
         // headers priority is (high to low):
         // 1. invoke-level headers
         // 2. client-level headers

--- a/src/types.ts
+++ b/src/types.ts
@@ -47,6 +47,10 @@ export type FunctionInvokeOptions = {
    * */
   headers?: { [key: string]: string }
   /**
+   * The HTTP verb of the request
+   */
+  method?: "POST"| "GET"| "PUT" | "PATCH" | "DELETE"
+  /**
    * The body of the request.
    */
   body?:


### PR DESCRIPTION
## What kind of change does this PR introduce?
It's a feature that adds support for different HTTP verbs in invoking functions. Edge functions now support different HTTP verbs (such as GET, PUT and DELETE) however the functions-js library didn't get updated to let users do that.

## What is the current behavior?
Edge functions now support different HTTP verbs (such as GET, PUT and DELETE) however the functions-js library didn't get updated to let users do that.

This is related to [this discussion](https://github.com/supabase/supabase/discussions/11753)

## What is the new behavior?
It keeps the default behaviour of calling with POST, however lets users to choose a different HTTP verb if they needed to. It is legacy compliant so using this new version doesn't break any legacy/existing code.

## Additional context
none at the moment