### PR TITLE
Fix `FunctionsError` class constructor

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -18,7 +18,7 @@ export class FunctionsError extends Error {
   context: any
   constructor(message: string, name = 'FunctionsError', context?: any) {
     super(message)
-    super.name = name
+    this.name = name
     this.context = context
   }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

#56

## What is the new behavior?

Fix errors related to the incorrect setup of FunctionsError class.

## Additional context

Fixes this:
```sh
./node_modules/@supabase/functions-js/src/types.ts:21:11
Type error: Only public and protected base class methods are accessible via the 'super' keyword.

  19 |   constructor(message: string, name = 'FunctionsError', context?: any) {
  20 |     super(message)
> 21 |     super.name = name
     |           ^
  22 |     this.context = context
  23 |   }
  24 | }
```
