### PR TITLE
Fixed exports in src/index.ts

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,12 @@
 export { FunctionsClient } from './FunctionsClient'
 export {
-  FunctionInvokeOptions,
   FunctionsError,
   FunctionsFetchError,
   FunctionsHttpError,
   FunctionsRelayError,
+} from './types'
+
+export type {
   FunctionsResponse,
+  FunctionInvokeOptions  
 } from './types'


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

[Issue#58](https://github.com/supabase/functions-js/issues/58)

## What is the new behavior?

Changes made in `src/index.ts`
Before:

``` typescript
export { FunctionsClient } from './FunctionsClient'
export {
  FunctionInvokeOptions,
  FunctionsError,
  FunctionsFetchError,
  FunctionsHttpError,
  FunctionsRelayError,
  FunctionsResponse,
} from './types'
```

Now:
``` typescript
export { FunctionsClient } from './FunctionsClient'
export {
  FunctionsError,
  FunctionsFetchError,
  FunctionsHttpError,
  FunctionsRelayError,
} from './types'

export type {
  FunctionsResponse,
  FunctionInvokeOptions  
} from './types'
```
