### PR TITLE
fix: fix error type in FunctionsResponseFailure

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -10,7 +10,7 @@ export interface FunctionsResponseSuccess<T> {
 }
 export interface FunctionsResponseFailure {
   data: null
-  error: any
+  error: FunctionsError
 }
 export type FunctionsResponse<T> = FunctionsResponseSuccess<T> | FunctionsResponseFailure
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

The type of `error` in FunctionsResponseFailureis `any`.

## What is the new behavior?

Set the type of `error` to `FunctionsError`.

## Additional context
Sad :(
```
× eslint --report-unused-disable-directives --max-warnings 0 --fix:

   61:19  error  Unsafe array destructuring of a tuple element with an `any` value                   @typescript-eslint/no-unsafe-assignment
   65:23  error  Unsafe argument of type `any` assigned to a parameter of type `string | undefined`  @typescript-eslint/no-unsafe-argument
   65:23  error  Unsafe member access .message on an `any` value                                     @typescript-eslint/no-unsafe-member-access
  127:19  error  Unsafe array destructuring of a tuple element with an `any` value                   @typescript-eslint/no-unsafe-assignment
  131:23  error  Unsafe argument of type `any` assigned to a parameter of type `string | undefined`  @typescript-eslint/no-unsafe-argument
  131:23  error  Unsafe member access .message on an `any` value                                     @typescript-eslint/no-unsafe-member-access
  150:19  error  Unsafe array destructuring of a tuple element with an `any` value                   @typescript-eslint/no-unsafe-assignment
  157:23  error  Unsafe argument of type `any` assigned to a parameter of type `string | undefined`  @typescript-eslint/no-unsafe-argument
  157:23  error  Unsafe member access .message on an `any` value                                     @typescript-eslint/no-unsafe-member-access
  227:23  error  Unsafe argument of type `any` assigned to a parameter of type `string | undefined`  @typescript-eslint/no-unsafe-argument
  227:23  error  Unsafe member access .message on an `any` value                                     @typescript-eslint/no-unsafe-member-access

✖ 11 problems (11 errors, 0 warnings)

```
