### PR TITLE
Fixed leaking resources when a fetch response body is not consumed

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -30,7 +30,7 @@ export class FunctionsClient {
 
   /**
    * Updates the authorization header
-   * @param token - the new jwt token sent in the authorisation header
+   * @param token - the new jwt token sent in the authorization header
    */
   setAuth(token: string) {
     this.headers.Authorization = `Bearer ${token}`
@@ -45,6 +45,7 @@ export class FunctionsClient {
     functionName: string,
     options: FunctionInvokeOptions = {}
   ): Promise<FunctionsResponse<T>> {
+    let response = null;
     try {
       const { headers, method, body: functionArgs } = options
 
@@ -77,7 +78,7 @@ export class FunctionsClient {
         }
       }
 
-      const response = await this.fetch(`${this.url}/${functionName}`, {
+      response = await this.fetch(`${this.url}/${functionName}`, {
         method: method || 'POST',
         // headers priority is (high to low):
         // 1. invoke-level headers
@@ -113,6 +114,10 @@ export class FunctionsClient {
 
       return { data, error: null }
     } catch (error) {
+      if (response && response.body) {
+        await response.body.cancel();
+      }
+
       return { data: null, error }
     }
   }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix (fixes https://github.com/supabase/functions-js/issues/65)

## What is the current behavior?

I am trying to write some negative tests for my edge functions, for example:
```
const testSomeFunction = async () => {
  const { data, error } = await supabaseUser.functions.invoke('some-function', {
    body: {
      userId: 'invalid-id'
    }
  })

  assertEquals(error.message, 'Edge Function returned a non-2xx status code')
  assertEquals(data, null)
}
```
But when running `deno test`, the test fails with:
```
error: Leaking resources:
  - A fetch response body (rid 18) was created during the test, but not consumed during the test. Consume or close the response body `ReadableStream`, e.g `await resp.text()` or `await resp.body.cancel()`.
```
But I cannot access the response to consume/close/cancel/... it.

## What is the new behavior?

The response body is cancelled if necessary.
