### PR TITLE
Directly pass through event streams

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -104,6 +104,8 @@ export class FunctionsClient {
         data = await response.json()
       } else if (responseType === 'application/octet-stream') {
         data = await response.blob()
+      } else if (responseType === 'text/event-stream') {
+        data = response
       } else if (responseType === 'multipart/form-data') {
         data = await response.formData()
       } else {


### PR DESCRIPTION
## What kind of change does this PR introduce?

Feature/bug fix: Passing through event streams so that OpenAI completions, etc. can be proxied

## What is the current behavior?

Event streams are concatenated and only returned at the end of the stream.

Please link any relevant issues here.

## What is the new behavior?

Event streams are directly passed so that they can be used properly.

Anything I should change elsewhere, like documentation?
