### PR TITLE
fix: bump ci/cd version

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -14,15 +14,15 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        node: ['18']
+        node: ['20']
 
     runs-on: ${{ matrix.os }}
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,15 +13,15 @@ jobs:
     name: Release / Node ${{ matrix.node }}
     strategy:
       matrix:
-        node: ['18']
+        node: ['20']
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,15 +13,15 @@ jobs:
     name: Run tests
     strategy:
       matrix:
-        node: ['18']
+        node: ['20']
 
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Set up Node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node }}
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ JS Client library to interact with Supabase Functions.
 
 ## testing
 
-To run tests you will need Node 18+.
+To run tests you will need Node 20+.
 
 You are going to need docker daemon running to execute tests.
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bump CI/CD versions (there were warnings about node 18 being deprecated):
<img width="1303" alt="image" src="https://github.com/supabase/functions-js/assets/5036432/ad76d2a7-fac0-4146-a6ed-ec83e5bd7d3b">


## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
