### PR TITLE
fix: trigger semantic release & export type FunctionRegion

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,6 @@ export {
   FunctionsFetchError,
   FunctionsHttpError,
   FunctionsRelayError,
-  FunctionsResponse,
-  FunctionRegion
+  FunctionRegion,
+  FunctionsResponse
 } from './types'


### PR DESCRIPTION
## What kind of change does this PR introduce?

I need to trigger a semantic release to get the type exported.
Unblocks: https://github.com/supabase/supabase-js/pull/964

## What is the current behavior?

Please link any relevant issues here.

## What is the new behavior?

Feel free to include screenshots if it includes visual changes.

## Additional context

Add any other context or screenshots.
