### PR TITLE
feat: add Edge Runtime global types

### DIFF
--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -1,20 +1,44 @@
 interface ModelOptions {
+  /**
+   * Pool embeddings by taking their mean. Applies only for `gte-small` model
+   */
   mean_pool?: boolean
+
+  /**
+   * Normalize the embeddings result. Applies only for `gte-small` model
+   */
   normalize?: boolean
+
+  /**
+   * Stream response from model. Applies only for LLMs like `mistral` (default: false)
+   */
   stream?: boolean
+
+  /**
+   * Automatically abort the request to the model after specified time (in seconds). Applies only for LLMs like `mistral` (default: 60)
+   */
   timeout?: number
 }
 
 interface Session {
+  /**
+   * Execute the given prompt in model session
+   */
   run(prompt: string, modelOptions?: ModelOptions): unknown
 }
 
 declare var Session: {
   prototype: Session
-  new (modelName: string, sessionOptions?: unknown): Session
+  /**
+   * Create a new model session using given model
+   */
+  new (model: string, sessionOptions?: unknown): Session
 }
 
 declare var Supabase: {
+  /**
+   * Provides AI related APIs
+   */
   readonly ai: {
     readonly Session: typeof Session
   }

--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -1,0 +1,21 @@
+interface ModelOptions {
+  mean_pool?: boolean
+  normalize?: boolean
+  stream?: boolean
+  timeout?: number
+}
+
+interface Session {
+  run(prompt: string, modelOptions?: ModelOptions): unknown
+}
+
+declare var Session: {
+  prototype: Session
+  new (modelName: string, sessionOptions?: unknown): Session
+}
+
+declare var Supabase: {
+  readonly ai: {
+    readonly Session: typeof Session
+  }
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR adds a type definition file which can be imported into edge functions to get Edge Runtime specific global types.

Then in an edge function these types can be added as:
```
/// <reference types="npm:https://esm.sh/@supabase/functions-js/src/edge-runtime.d.ts" />
```