### PR TITLE
fix: use Supabase namespace for non-std Supabase APIs

### DIFF
--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -1,45 +1,47 @@
-interface ModelOptions {
-  /**
-   * Pool embeddings by taking their mean. Applies only for `gte-small` model
-   */
-  mean_pool?: boolean
+declare namespace Supabase {
+  export interface ModelOptions {
+    /**
+     * Pool embeddings by taking their mean. Applies only for `gte-small` model
+     */
+    mean_pool?: boolean
 
-  /**
-   * Normalize the embeddings result. Applies only for `gte-small` model
-   */
-  normalize?: boolean
+    /**
+     * Normalize the embeddings result. Applies only for `gte-small` model
+     */
+    normalize?: boolean
 
-  /**
-   * Stream response from model. Applies only for LLMs like `mistral` (default: false)
-   */
-  stream?: boolean
+    /**
+     * Stream response from model. Applies only for LLMs like `mistral` (default: false)
+     */
+    stream?: boolean
 
-  /**
-   * Automatically abort the request to the model after specified time (in seconds). Applies only for LLMs like `mistral` (default: 60)
-   */
-  timeout?: number
-}
+    /**
+     * Automatically abort the request to the model after specified time (in seconds). Applies only for LLMs like `mistral` (default: 60)
+     */
+    timeout?: number
+  }
 
-interface Session {
-  /**
-   * Execute the given prompt in model session
-   */
-  run(prompt: string, modelOptions?: ModelOptions): unknown
-}
+  export class Session {
+    /**
+     * Create a new model session using given model
+     */
+    constructor(model: string, sessionOptions?: unknown)
 
-declare var Session: {
-  prototype: Session
-  /**
-   * Create a new model session using given model
-   */
-  new (model: string, sessionOptions?: unknown): Session
-}
+    /**
+     * Execute the given prompt in model session
+     */
+    run(prompt: string, modelOptions?: ModelOptions): unknown
+  }
 
-declare var Supabase: {
   /**
    * Provides AI related APIs
    */
-  readonly ai: {
+  export interface Ai {
     readonly Session: typeof Session
   }
+
+  /**
+   * Provides AI related APIs
+   */
+  export const ai: Ai
 }


### PR DESCRIPTION
c.f.:
- https://deno.land/api@v1.42.3?s=Deno
- https://github.com/denoland/deno/releases/download/v1.42.3/lib.deno.d.ts