### PR TITLE
fix: jsr publish write permissions.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
 
     permissions:
-      contents: read
+      contents: write
       id-token: write
 
     steps:


### PR DESCRIPTION
Job needs write permissions to be able to create release: https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs#overview 