### PR TITLE
fix: allow wirting to issues.

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
 
     permissions:
       contents: write
+      issues: write
       id-token: write
 
     steps:


### PR DESCRIPTION
semantic-release adds a comment to issues, need to allow this in the release action.