### PR TITLE
feat/Function query params

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -88,6 +88,14 @@ export class FunctionsClient {
         }
       }
 
+      if (options.params) {
+        const searchParams = new URLSearchParams()
+        for (const key in options.params) {
+          searchParams.set(key, options.params[key])
+        }
+        functionName = `${functionName}?${searchParams.toString()}`
+      }
+
       const response = await this.fetch(`${this.url}/${functionName}`, {
         method: method || 'POST',
         // headers priority is (high to low):

--- a/src/types.ts
+++ b/src/types.ts
@@ -83,4 +83,8 @@ export type FunctionInvokeOptions = {
     | ReadableStream<Uint8Array>
     | Record<string, any>
     | string
+  /**
+   * The query parameters to send with the request.
+   */
+  params?: Record<string, any>
 }

--- a/test/spec/params.spec.ts
+++ b/test/spec/params.spec.ts
@@ -38,13 +38,17 @@ describe('params reached to function', () => {
     })
 
     log('invoke mirror')
-    const { data, error } = await fclient.invoke<MirrorResponse>('mirror', {})
+    const { data, error } = await fclient.invoke<MirrorResponse>('mirror', {
+      params: {
+        hello: 'world',
+      }
+    })
 
     log('assert no error')
     expect(error).toBeNull()
 
     const expected = {
-      url: 'http://localhost:8000/mirror',
+      url: 'http://localhost:8000/mirror?hello=world',
       method: 'POST',
       headers: data?.headers ?? [],
       body: '',


### PR DESCRIPTION
## What kind of change does this PR introduce?

New feature added, query params support

## What is the current behavior?

Currently the api doesnt support query params

## What is the new behavior?

Be able to use query params from options.

Current way:
```ts
const { data, error } = await fclient.invoke<MirrorResponse>('mirror?hello=world', {})
```

New:
```ts
const { data, error } = await fclient.invoke<MirrorResponse>('mirror', {
   params: {
     hello: 'world',
   }
})
```

This is specially good when you're using verbs like get and delete. I've used the axios way to receive qs, the parameter named "params"
