### PR TITLE
feat(ai): add type definition for `Pipeline` API

### DIFF
--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -61,7 +61,7 @@ declare namespace Supabase {
   /** Parameters specific to feature extraction pipelines. */
   export type FeatureExtractionOptions = {
     /** Pool embeddings by taking their mean. */
-    mean_pool?: boolean;
+    meanPool?: boolean;
     /** Whether or not to normalize the embeddings in the last dimension. */
     normalize?: boolean;
   };
@@ -81,7 +81,7 @@ declare namespace Supabase {
     /** The text to classify.*/
     text: string;
     /** The set of possible class labels to classify.*/
-    candidate_labels: string[];
+    candidateLabels: string[];
   };
 
   /** Parameters specific to zero-shot classification pipelines.*/
@@ -92,14 +92,14 @@ declare namespace Supabase {
      * If `true`, the labels are considered independent and probabilities are normalized for each candidate by doing a softmax
      * of the entailment score vs. the contradiction score.
      */
-    multi_label?: boolean;
+    multiLabel?: boolean;
     /**
      * The template used to turn each label into an NLI-style hypothesis.
      * This template must include a `{}` or similar syntax for the candidate label to be inserted into the template.
      * For example, the default template is `"This example is {}."` With the candidate label `"sports"`, this would be fed into the model like `"<cls> sequence to classify <sep> This example is sports . <sep>".`
      * The default template works well in many cases, but it may be worthwhile to experiment with different templates depending on their task setting.
      */
-    hypothesis_template?: string;
+    hypothesisTemplate?: string;
   };
 
   type PipelineTasks =
@@ -195,7 +195,7 @@ declare namespace Supabase {
      * const classifier = new Supabase.ai.Pipeline('zero-shot-classification');
      * const output = await classifier({
      *  text: 'one day I will see the world',
-     *  candidate_labels: ['travel', 'cooking', 'exploration']
+     *  candidateLabels: ['travel', 'cooking', 'exploration']
      * });
      *
      * // output: [{label: "travel", score: 0.797}, {label: "exploration", score: 0.199}, {label: "cooking", score: 0.002}]
@@ -207,9 +207,9 @@ declare namespace Supabase {
      * const classifier = new Supabase.ai.Pipeline('zero-shot-classification');
      * const input = {
      *  text: 'one day I will see the world',
-     *  candidate_labels: ['travel', 'cooking', 'exploration']
+     *  candidateLabels: ['travel', 'cooking', 'exploration']
      * };
-     * const output = await classifier(input, { multi_label: true });
+     * const output = await classifier(input, { multiLabel: true });
      *
      * // output: [{label: "travel", score: 0.994}, {label: "exploration", score: 0.938}, {label: "cooking", score: 0.001}]
      *
@@ -220,9 +220,9 @@ declare namespace Supabase {
      * const classifier = new Supabase.ai.Pipeline('zero-shot-classification');
      * const input = {
      *  text: 'one day I will see the world',
-     *  candidate_labels: ['travel', 'cooking', 'exploration']
+     *  candidateLabels: ['travel', 'cooking', 'exploration']
      * };
-     * const output = await classifier(input, { hypothesis_template: "This example is NOT about {}");
+     * const output = await classifier(input, { hypothesisTemplate: "This example is NOT about {}");
      *
      * // output: [{label: "cooking", score: 0.47}, {label: "exploration", score: 0.26}, {label: "travel", score: 0.26}]
      *

--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -1,37 +1,50 @@
 declare namespace Supabase {
+  /**
+   * Provides AI related APIs
+   */
+  export interface Ai {
+    readonly Session: typeof Session;
+    readonly Pipeline: typeof Pipeline;
+  }
+
+  /**
+   * Provides AI related APIs
+   */
+  export const ai: Ai;
+
   export interface ModelOptions {
     /**
      * Pool embeddings by taking their mean. Applies only for `gte-small` model
      */
-    mean_pool?: boolean
+    mean_pool?: boolean;
 
     /**
      * Normalize the embeddings result. Applies only for `gte-small` model
      */
-    normalize?: boolean
+    normalize?: boolean;
 
     /**
      * Stream response from model. Applies only for LLMs like `mistral` (default: false)
      */
-    stream?: boolean
+    stream?: boolean;
 
     /**
      * Automatically abort the request to the model after specified time (in seconds). Applies only for LLMs like `mistral` (default: 60)
      */
-    timeout?: number
+    timeout?: number;
 
     /**
      * Mode for the inference API host. (default: 'ollama')
      */
-    mode?: 'ollama' | 'openaicompatible'
-    signal?: AbortSignal
+    mode?: 'ollama' | 'openaicompatible';
+    signal?: AbortSignal;
   }
 
   export class Session {
     /**
      * Create a new model session using given model
      */
-    constructor(model: string, sessionOptions?: unknown)
+    constructor(model: string, sessionOptions?: unknown);
 
     /**
      * Execute the given prompt in model session
@@ -39,20 +52,93 @@ declare namespace Supabase {
     run(
       prompt:
         | string
+        | string[]
         | Omit<import('openai').OpenAI.Chat.ChatCompletionCreateParams, 'model' | 'stream'>,
-      modelOptions?: ModelOptions
-    ): unknown
+      modelOptions?: ModelOptions,
+    ): unknown;
   }
 
-  /**
-   * Provides AI related APIs
-   */
-  export interface Ai {
-    readonly Session: typeof Session
-  }
+  /** Parameters specific to feature extraction pipelines. */
+  export type FeatureExtractionOptions = {
+    /** Pool embeddings by taking their mean. */
+    mean_pool?: boolean;
+    /** Whether or not to normalize the embeddings in the last dimension. */
+    normalize?: boolean;
+  };
+
+  /** The features computed by the model.*/
+  export type FeatureExtractionOutput = number[];
+
+  /** The classifications computed by the model.*/
+  export type TextClassificationOutput = {
+    /** The label predicted. */
+    label: string;
+    /** The corresponding probability. */
+    score: number;
+  };
 
   /**
-   * Provides AI related APIs
+   * Pipelines provide a high-level, easy to use, API for running machine learning models.
    */
-  export const ai: Ai
+  export type PipelineTasks = {
+    /**
+     * Feature extraction pipeline using no model head. This pipeline extracts the hidden
+     * states from the base transformer, which can be used as features in downstream tasks.
+     *
+     * **Example:** Instantiate pipeline using the `Pipeline` class.
+     * ```javascript
+     * const extractor = new Supabase.ai.Pipeline('feature-extraction');
+     * const output = await extractor('This is a simple test.');
+     *
+     * // Embeddings: [0.05939, 0.02165, ...]
+     *
+     * ```
+     */
+    ['feature-extraction']: <T = string | string[]>(
+      input: T,
+      opts?: FeatureExtractionOptions,
+    ) => Promise<T extends string[] ? FeatureExtractionOutput[] : FeatureExtractionOutput>;
+    /**
+     * Feature extraction pipeline using no model head.
+     * This pipeline does the same as `'feature-extraction'` but using the `'Supabase/gte-small'` as default model.
+     */
+    ['supabase-gte']: PipelineTasks['feature-extraction'];
+    /**
+     * Feature extraction pipeline using no model head.
+     * This pipeline does the same as `'feature-extraction'` but using the `'Supabase/gte-small'` as default model.
+     */
+    ['gte-small']: PipelineTasks['feature-extraction'];
+    /**
+     * Text classification pipeline using any `ModelForSequenceClassification`.
+     *
+     * **Example:** Instantiate pipeline using the `Pipeline` class.
+     * ```javascript
+     * const classifier = new Supabase.ai.Pipeline('sentiment-analysis');
+     * const output = await classifier('I love Supabase!');
+     *
+     * // Sentiment: {'label': 'POSITIVE', 'score': 0.999817686}
+     *
+     * ```
+     */
+    ['sentiment-analysis']: <T = string | string[]>(
+      input: T,
+    ) => Promise<T extends string[] ? TextClassificationOutput[] : TextClassificationOutput>;
+  };
+
+  /**
+   * Pipelines provide a high-level, easy to use, API for running machine learning models.
+   */
+  export class Pipeline<T extends keyof PipelineTasks> {
+    /**
+     * Create a new pipeline using given task
+     * @param task The task of the pipeline.
+     * @param variant Witch model variant to use by the pipeline.
+     */
+    constructor(task: T, variant?: string);
+
+    /**
+     * Executes the given input in the pipeline.
+     */
+    run: PipelineTasks[T];
+  }
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

This PR introduce the typescript defs for [add support for custom ai models #368](https://github.com/supabase/edge-runtime/pull/368).