### PR TITLE
fix: add a type for `EdgeRuntime.waitUntil`

### DIFF
--- a/src/edge-runtime.d.ts
+++ b/src/edge-runtime.d.ts
@@ -56,3 +56,7 @@ declare namespace Supabase {
    */
   export const ai: Ai
 }
+
+declare namespace EdgeRuntime {
+  export function waitUntil<T>(promise: Promise<T>): Promise<T>;
+}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## Description

Adds typing for `EdgeRuntime.waitUntil` to edge-runtime.d.ts.