### PR TITLE
feat: add abort signal option to invoke function

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -83,4 +83,8 @@ export type FunctionInvokeOptions = {
     | ReadableStream<Uint8Array>
     | Record<string, any>
     | string
+  /**
+   * The AbortSignal to use for the request.
+   * */
+  signal?: AbortSignal
 }


### PR DESCRIPTION
## What kind of change does this PR introduce?

Adds support for  passing an AbortSignal to function invokations

## What is the current behavior?

Functions cannot be aborted. This is bad if you for example use a function to fetch input autocompletion results, as you want to cancel outdated requests if the input changes.

Please link any relevant issues here.

https://github.com/orgs/supabase/discussions/27660

## What is the new behavior?

Functions can be cancelled by adding the `signal` optionrr

