### PR TITLE
Ignore type definitions in coverage metrics

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -13,6 +13,7 @@ const config: Config.InitialOptions = {
     'src/**/*.{ts,tsx}',
     '!src/version.ts',
     '!src/index.ts',
+    '!**/*.d.ts',
   ],
   coverageProvider: 'v8',
   coverageThreshold: {


### PR DESCRIPTION
## What kind of change does this PR introduce?
Type definition files (.d.ts files) should not be included in coverage calculations. They are TypeScript declaration files that only contain type information and are removed during compilation to JavaScript. Including in the coverage reportartificially lowers the overall metric