### PR TITLE
fix: Consume Response object on Error

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -102,10 +102,12 @@ export class FunctionsClient {
 
       const isRelayError = response.headers.get('x-relay-error')
       if (isRelayError && isRelayError === 'true') {
+        response.body?.cancel()
         throw new FunctionsRelayError(response)
       }
 
       if (!response.ok) {
+        response.body?.cancel()
         throw new FunctionsHttpError(response)
       }
 


### PR DESCRIPTION
## What kind of change does this PR introduce?

Bug fix

## What is the current behavior?

Details of the bug have been described in #65. 

When using Deno to test edge functions, Response bodies with status codes not matching `2xx` are not consumed before the `invoke` function returns with the `FunctionError` object, causing a leak.
This is detrimental for testing edge functions as all tests that expect errors fail due to the leak.

## What is the new behavior?

Response bodies are cancelled before returning, closing the response and mitigating the leak.

Resolves #65