### PR TITLE
fix: include response object in FunctionsClient invoke method return

### DIFF
--- a/src/FunctionsClient.ts
+++ b/src/FunctionsClient.ts
@@ -127,9 +127,9 @@ export class FunctionsClient {
         data = await response.text()
       }
 
-      return { data, error: null }
+      return { data, error: null, response }
     } catch (error) {
-      return { data: null, error }
+      return { data: null, error, response: error instanceof FunctionsHttpError || error instanceof FunctionsRelayError ? error.context : undefined }
     }
   }
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,15 +2,16 @@ export type Fetch = typeof fetch
 
 /**
  * Response format
- *
  */
 export interface FunctionsResponseSuccess<T> {
   data: T
   error: null
+  response?: Response
 }
 export interface FunctionsResponseFailure {
   data: null
   error: any
+  response?: Response
 }
 export type FunctionsResponse<T> = FunctionsResponseSuccess<T> | FunctionsResponseFailure
 
@@ -62,7 +63,7 @@ export enum FunctionRegion {
 export type FunctionInvokeOptions = {
   /**
    * Object representing the headers to send with the request.
-   * */
+   */
   headers?: { [key: string]: string }
   /**
    * The HTTP verb of the request

--- a/test/spec/hello.spec.ts
+++ b/test/spec/hello.spec.ts
@@ -34,12 +34,15 @@ describe('basic tests (hello function)', () => {
     })
 
     log('invoke hello')
-    const { data, error } = await fclient.invoke<string>('hello', {})
+    const { data, error, response } = await fclient.invoke<string>('hello', {})
 
     log('assert no error')
     expect(error).toBeNull()
     log(`assert ${data} is equal to 'Hello World'`)
     expect(data).toEqual('Hello World')
+    log('assert response object is present')
+    expect(response).toBeDefined()
+    expect(response).toBeInstanceOf(Response)
   })
 
   test('invoke hello with setAuth', async () => {
@@ -71,12 +74,14 @@ describe('basic tests (hello function)', () => {
     fclient.setAuth(wrongKey)
 
     log('invoke hello')
-    const { data, error } = await fclient.invoke<string>('hello', {})
+    const { data, error, response } = await fclient.invoke<string>('hello', {})
 
     log('check error')
     expect(error).not.toBeNull()
     expect(error?.message).toEqual('Relay Error invoking the Edge Function')
     expect(data).toBeNull()
+    log('assert response object is present in error case')
+    expect(response).toBeDefined()
   })
 
   test('invoke hello: auth override by setAuth wrong key', async () => {


### PR DESCRIPTION
- Updated invoke method to include response object in both success and error cases
- Added test cases to verify response object is present in function invocations
- Ensures compliance with FunctionsResponse type definition

Fixes #65 . Supersedes #98
