### PR TITLE
chore: trigger action from forks

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -38,7 +38,7 @@ jobs:
       (
         github.event_name == 'workflow_dispatch' ||
         github.event_name == 'push' ||
-        (github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'trigger: preview'))
+        (github.event_name == 'pull_request_target' && contains(github.event.pull_request.labels.*.name, 'trigger: preview'))
       )
     runs-on: ubuntu-latest
     outputs:
@@ -122,7 +122,7 @@ jobs:
                   triggering_pr: prNumber.toString(),
                   preview_url: '${{ needs.preview.outputs.preview-url }}',
                   package_name: '${{ needs.preview.outputs.package-name }}',
-                  triggering_sha: context.eventName === 'pull_request' ? context.payload.pull_request.head.sha : context.sha
+                  triggering_sha: context.eventName === 'pull_request_target' ? context.payload.pull_request.head.sha : context.sha
                 }
               });
               
@@ -134,7 +134,7 @@ jobs:
             }
 
       - name: Find existing preview comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: peter-evans/find-comment@v3
         id: find-comment
         with:
@@ -144,7 +144,7 @@ jobs:
           body-includes: '<!-- functions-js-preview-status -->'
 
       - name: Create or update preview comment
-        if: github.event_name == 'pull_request'
+        if: github.event_name == 'pull_request_target'
         uses: peter-evans/create-or-update-comment@v4
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## What kind of change does this PR introduce?

Using `pull_request_target` to access secrets when PRs come from forks. This is secure, since we control which PRs trigger the preview.

## What is the current behavior?

The workflow cannot run on PRs from forks because it does not have access to `app-id`.

## What is the new behavior?

Use `pull_request_target` to get access to secrets.
