### PR TITLE
chore: fix preview release to use correct target

### DIFF
--- a/.github/workflows/preview-release.yml
+++ b/.github/workflows/preview-release.yml
@@ -15,24 +15,25 @@ on:
         description: 'Target branch for supabase-js tests'
         type: string
         default: 'master'
-
-  # Push to master - only when source code changes
+  
+  # Push to main - only when source code changes
   push:
     branches:
-      - master
+      - main
     paths:
       - 'src/**'
       - 'package.json'
       - 'package-lock.json'
       - 'tsconfig.json'
-
+  
   # PR triggers - only when labeled
-  pull_request:
+  # Using pull_request_target to access secrets when PRs come from forks
+  pull_request_target:
     types: [labeled, synchronize]
 
 jobs:
   preview:
-    # Run only for PRs with 'trigger: preview' label or pushes to master
+    # Run only for PRs with 'trigger: preview' label or pushes to main
     if: >
       github.repository == 'supabase/functions-js' &&
       (
@@ -47,6 +48,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          # For pull_request_target, we need to explicitly checkout the PR's head
+          ref: ${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.sha || github.sha }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -106,10 +110,10 @@ jobs:
           script: |
             const prNumber = context.issue.number || 'push';
             const triggeringRepo = context.repo.repo;
-            // Use input target_branch if workflow_dispatch, otherwise default to master
+            // Use input target_branch if workflow_dispatch, otherwise default to main
             const targetBranch = context.eventName === 'workflow_dispatch' && context.payload.inputs?.target_branch
               ? context.payload.inputs.target_branch
-              : 'master';
+              : 'main';
 
             try {
               const response = await github.rest.actions.createWorkflowDispatch({
@@ -153,11 +157,11 @@ jobs:
           body: |
             <!-- functions-js-preview-status -->
             🚀 **Preview release created!**
-
+            
             supabase-js CI tests have been automatically triggered on feature branch to verify compatibility.
-
+            
             **Preview package:** `${{ needs.preview.outputs.preview-url }}`
-
+            
             Results will be posted here once testing is complete.
-
+            
           edit-mode: replace


### PR DESCRIPTION
## What kind of change does this PR introduce?

Fix target branch from `master` to `main`

## What is the current behavior?

Target branch is `master` which does not exist.

## What is the new behavior?

Target branch is `main`.
